### PR TITLE
Implement quick fix for disconnects sending all varb data

### DIFF
--- a/src/main/java/com/Crowdsourcing/varbits/CrowdsourcingVarbits.java
+++ b/src/main/java/com/Crowdsourcing/varbits/CrowdsourcingVarbits.java
@@ -126,7 +126,8 @@ public class CrowdsourcingVarbits
 	public void onGameStateChanged(GameStateChanged gameStateChanged)
 	{
 		if (gameStateChanged.getGameState().equals(GameState.HOPPING)
-			|| gameStateChanged.getGameState().equals(GameState.LOGGING_IN))
+			|| gameStateChanged.getGameState().equals(GameState.LOGGING_IN)
+			|| gameStateChanged.getGameState().equals(GameState.CONNECTION_LOST))
 		{
 			initializingTick = client.getTickCount() + 5;
 			shutDown();


### PR DESCRIPTION
* I think this fails for longer disconnects since the flow is `CONNECTION_LOST` -> `LOGGED_IN` -> `varb changes`. Checking `LOGGED_IN` on its own causes issues since you change to that gamestate while running around
* Can test using dev mode -> dev tools -> disconnect. Might want to add logging while testing to see when VarData objs are created