### PR TITLE
Update runeLiteVersion in gradle build to use latest release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.32.4'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
This should prevent the hassle of current and future gradle builds attempting to run an outdated RuneLite version.