### PR TITLE
Add petfish messages with fishing lvl metadata

### DIFF
--- a/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
+++ b/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
@@ -117,6 +117,11 @@ public class CrowdsourcingMessages
 	private static final String TUNA_SUCCESS = "You manage to cook a tuna.";
 	private static final String TUNA_FAIL = "You accidentally burn the tuna.";
 
+	// Pet fish tiny bluefish, greenfish, spinefish
+	private static final String PET_FISH_BLUEFISH = "...and you catch a Tiny Bluefish!";
+	private static final String PET_FISH_GREENFISH = "...and you catch a Tiny Greenfish!";
+	private static final String PET_FISH_SPINEFISH = "...and you catch a Tiny Spinefish!";
+
 	private HashMap<String, Object> createSkillMap(Skill s)
 	{
 		HashMap<String, Object> h = new HashMap<>();
@@ -240,6 +245,11 @@ public class CrowdsourcingMessages
 		if (MASTER_FARMER_PICKPOCKET.matcher(message).matches())
 		{
 			return createSkillMap(Skill.FARMING);
+		}
+
+		if (PET_FISH_BLUEFISH.equals(message) || PET_FISH_GREENFISH.equals(message) || PET_FISH_SPINEFISH.equals(message))
+		{
+			return createSkillMap(Skill.FISHING);
 		}
 
 		return null;


### PR DESCRIPTION
Useful for tracking the catch rate of [pet fish](https://oldschool.runescape.wiki/w/Fishbowl_(pet)), which is currently estimated to be
![graph](https://github.com/leejt/osrs-wiki-crowdsourcing/assets/53493631/e1acb976-c411-41ab-929f-7abfcb468a1f)
based on the following data
|Fishing level|Bluefish|Greenfish|Spinefish|
|:----------:|:-------:|:----------:|:--------:|
|1|197 (90%)|22 (10%)|0|
|69|658 (66%)|332 (34%)|0|
|70|416 (40%)|409 (40%)|201 (20%)|
|86|673 (39%)|666 (39%)|375 (22%)|

Because 1) the graph is conditional and 2) the spinefish level 70 requirement uses the static base level, it is unknown whether the standard dumb interpolation is used or not. This chat message crowdsourcing with fishing level will hopefully be able to answer that question in a few years time. If not, then we at least know that tiny pet fishing is a contender for least used piece of content.