### PR TITLE
Replace WidgetInfo and WidgetID with ComponentID and InterfaceID

### DIFF
--- a/src/main/java/com/Crowdsourcing/clues/CrowdsourcingClues.java
+++ b/src/main/java/com/Crowdsourcing/clues/CrowdsourcingClues.java
@@ -11,8 +11,8 @@ import static net.runelite.api.MenuAction.CC_OP;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
 import com.Crowdsourcing.CrowdsourcingManager;
@@ -75,7 +75,7 @@ public class CrowdsourcingClues {
        if (clueId == -1) {
            return;
        }
-       final Widget clueTextWidget = client.getWidget(WidgetInfo.CLUE_SCROLL_TEXT);
+       final Widget clueTextWidget = client.getWidget(ComponentID.CLUESCROLL_TEXT);
        if (clueTextWidget != null) {
            String candidateClueText = clueTextWidget.getText();
            if (clueId == ItemID.CLUE_SCROLL_MASTER && candidateClueText.equals(clueText)) {

--- a/src/main/java/com/Crowdsourcing/dialogue/CrowdsourcingDialogue.java
+++ b/src/main/java/com/Crowdsourcing/dialogue/CrowdsourcingDialogue.java
@@ -31,8 +31,8 @@ import net.runelite.api.Client;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 import com.Crowdsourcing.CrowdsourcingManager;
 
@@ -56,8 +56,8 @@ public class CrowdsourcingDialogue
 	@Subscribe
 	public void onGameTick(GameTick tick)
 	{
-		Widget spriteWidget = client.getWidget(WidgetInfo.DIALOG_SPRITE_SPRITE);
-		Widget textWidget = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+		Widget spriteWidget = client.getWidget(ComponentID.DIALOG_SPRITE_SPRITE);
+		Widget textWidget = client.getWidget(ComponentID.DIALOG_SPRITE_TEXT);
 		if (spriteWidget != null && textWidget != null && (!textWidget.getText().equals(lastSpriteText)
 			|| spriteWidget.getItemId() != lastItemId))
 		{

--- a/src/main/java/com/Crowdsourcing/mlm/CrowdsourcingMLM.java
+++ b/src/main/java/com/Crowdsourcing/mlm/CrowdsourcingMLM.java
@@ -48,8 +48,8 @@ import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 import com.Crowdsourcing.CrowdsourcingManager;
 
@@ -86,7 +86,7 @@ public class CrowdsourcingMLM
 			return;
 		}
 
-		Widget widgetSpriteText = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
+		Widget widgetSpriteText = client.getWidget(ComponentID.DIALOG_SPRITE_TEXT);
 
 		if (widgetSpriteText == null)
 		{

--- a/src/main/java/com/Crowdsourcing/quest_log/CrowdsourcingQuestLog.java
+++ b/src/main/java/com/Crowdsourcing/quest_log/CrowdsourcingQuestLog.java
@@ -6,8 +6,9 @@ import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.eventbus.Subscribe;
 
 @Slf4j
@@ -186,9 +187,9 @@ public class CrowdsourcingQuestLog
 	private void onWidgetLoaded(WidgetLoaded event)
 	{
 		// Only check if the diary/quest widget text is changing
-		if (event.getGroupId() != WidgetInfo.DIARY_QUEST_WIDGET_TEXT.getGroupId())
+		if (event.getGroupId() != InterfaceID.DIARY)
 			return;
-		Widget w = client.getWidget(WidgetInfo.DIARY_QUEST_WIDGET_TEXT);
+		Widget w = client.getWidget(ComponentID.DIARY_TEXT);
 		if (w == null)
 			return;
 
@@ -207,7 +208,7 @@ public class CrowdsourcingQuestLog
 		}
 
 		// Get the title and figure out if this is a quest.
-		Widget titleWidget = client.getWidget(WidgetInfo.DIARY_QUEST_WIDGET_TITLE);
+		Widget titleWidget = client.getWidget(ComponentID.DIARY_TITLE);
 		if (titleWidget == null || titleWidget.getText() == null)
 			return;
 		String key = titleWidget.getText().substring("<col=7f0000>".length(), titleWidget.getText().length()-6);


### PR DESCRIPTION
Replaces deprecated uses of WidgetID and WidgetInfo with ComponentID and InterfaceID so plugin-hub CI won't fail for using those.