### PR TITLE
Add crowdsourcing for widgets without sprites + skill metadata

### DIFF
--- a/src/main/java/com/Crowdsourcing/dialogue/CrowdsourcingDialogue.java
+++ b/src/main/java/com/Crowdsourcing/dialogue/CrowdsourcingDialogue.java
@@ -41,7 +41,8 @@ import com.Crowdsourcing.CrowdsourcingManager;
 @Slf4j
 public class CrowdsourcingDialogue
 {
-	private static final String CRATE_4714_CATLIKE_AGILITY = "... and using your catlike agility land on all fours at the bottom of a large cavern!";
+	private static final String CRATE_4714_CATLIKE_AGILITY_ATTEMPT = "You begin to lower yourself into the hole...";
+	private static final String CRATE_4714_CATLIKE_AGILITY_SUCCESS = "... and using your catlike agility land on all fours at the bottom of a large cavern!";
 
 	@Inject
 	private Client client;
@@ -68,7 +69,8 @@ public class CrowdsourcingDialogue
 
 	public HashMap<String, Object> getMetadataForMessage(String message)
 	{
-		if (CRATE_4714_CATLIKE_AGILITY.equals(message))
+		if (CRATE_4714_CATLIKE_AGILITY_ATTEMPT.equals(message) ||
+			CRATE_4714_CATLIKE_AGILITY_SUCCESS.equals(message))
 		{
 			return createSkillMap(Skill.AGILITY);
 		}

--- a/src/main/java/com/Crowdsourcing/dialogue/DoubleSpriteTextData.java
+++ b/src/main/java/com/Crowdsourcing/dialogue/DoubleSpriteTextData.java
@@ -25,6 +25,7 @@
 
 package com.Crowdsourcing.dialogue;
 
+import java.util.HashMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import net.runelite.api.coords.WorldPoint;
@@ -38,4 +39,5 @@ public class DoubleSpriteTextData
     private int itemId2;
     private final boolean isInInstance;
     private final WorldPoint location;
+    private HashMap<String, Object> metadata;
 }

--- a/src/main/java/com/Crowdsourcing/dialogue/TextData.java
+++ b/src/main/java/com/Crowdsourcing/dialogue/TextData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Weird Gloop <admin@weirdgloop.org>
+ * Copyright (c) 2024, Weird Gloop <admin@weirdgloop.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,10 +32,9 @@ import net.runelite.api.coords.WorldPoint;
 
 @Data
 @AllArgsConstructor
-public class SpriteTextData
+public class TextData
 {
 	private String text;
-	private int itemId;
 	private final boolean isInInstance;
 	private final WorldPoint location;
 	private HashMap<String, Object> metadata;


### PR DESCRIPTION
Example of widget without sprite that now gets skill metadata:
![image](https://github.com/leejt/osrs-wiki-crowdsourcing/assets/53493631/a6a1a94e-0a41-489d-beca-8c7f401052f8)
