### PR TITLE
Add pickable chests and doors

### DIFF
--- a/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
+++ b/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
@@ -63,6 +63,16 @@ public class CrowdsourcingMessages
 	private static final String ZOGRE_COFFIN_FAIL = "You fail to pick the lock - your fingers get numb from fumbling with the lock.";
 	private static final String ZOGRE_COFFIN_LOCKPICK_SNAPS = "Your lockpick snaps.";
 
+	// Pickable doors
+	private static final String PICKLOCK_DOOR_SUCCESS = "You manage to pick the lock.";
+	private static final String PICKLOCK_DOOR_FAIL = "You fail to pick the lock.";
+	private static final String PICKLOCK_DOOR_TRAP = "You have activated a trap on the lock.";
+
+	// Pickable chests
+	private static final String PICKLOCK_CHEST_SUCCESS = "You manage to unlock the chest.";
+	private static final String PICKLOCK_CHEST_FAIL = "You fail to picklock the chest.";
+	private static final String PICKLOCK_CHEST_TRAP = "You have activated a trap on the chest.";
+
 	// Viyeldi Caves rock mining
 	private static final String VIYELDI_ROCK_MINING_SUCCESS = "You manage to smash the rock to bits.";
 	private static final String VIYELDI_ROCK_MINING_FAIL = "The pick clangs heavily against the rock face and the vibrations rattle your nerves.";
@@ -179,7 +189,15 @@ public class CrowdsourcingMessages
 			return createSkillMap(Skill.THIEVING);
 		}
 
-		if (ZOGRE_COFFIN_SUCCESS.equals(message) || ZOGRE_COFFIN_FAIL.equals(message) || ZOGRE_COFFIN_LOCKPICK_SNAPS.equals(message))
+		if (ZOGRE_COFFIN_SUCCESS.equals(message)
+			|| ZOGRE_COFFIN_FAIL.equals(message)
+			|| ZOGRE_COFFIN_LOCKPICK_SNAPS.equals(message)
+			|| PICKLOCK_DOOR_SUCCESS.equals(message)
+			|| PICKLOCK_DOOR_FAIL.equals(message)
+			|| PICKLOCK_DOOR_TRAP.equals(message)
+			|| PICKLOCK_CHEST_SUCCESS.equals(message)
+			|| PICKLOCK_CHEST_FAIL.equals(message)
+			|| PICKLOCK_CHEST_TRAP.equals(message))
 		{
 			boolean hasLockpick = false;
 			boolean hasHairClip = false;


### PR DESCRIPTION
Adds tracking for some [chests](https://oldschool.runescape.wiki/w/Chest_(Aldarin_Villas)) and [doors](https://oldschool.runescape.wiki/w/Door_(Yanille_Dungeon)), checking thieving level and whether player is using a lockpick.