### PR TITLE
Track herblore level for mastering mixology orders

### DIFF
--- a/src/main/java/com/Crowdsourcing/varbits/VarData.java
+++ b/src/main/java/com/Crowdsourcing/varbits/VarData.java
@@ -24,6 +24,7 @@
  */
 package com.Crowdsourcing.varbits;
 
+import java.util.HashMap;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import net.runelite.api.coords.WorldPoint;
@@ -39,4 +40,5 @@ public class VarData
 	private final int tick;
 	private final boolean isInInstance;
 	private final WorldPoint location;
+	private HashMap<String, Object> metadata;
 }


### PR DESCRIPTION
The new mastering mixology minigame uses 3 varbits for your current orders, 11315, 11317, and 11319. A value of 0 means no order, otherwise it's an index in this list:
1. Mammoth might mix
2. Mystic mana amalgam
3. Marley's moonlight
4. Alco augmentator
5. Azure aura mix
6. Aqualux amalgam
7. Liplack liquor
8. Megalite liquid
9. Anti leech lotion
10. Mixalot

This adds metadata containing skill level like there is for messages, because you only receive orders for potions you have the level to make. If we just queried the data as it is today it would be biased in favor of lower level orders, so we need to control for herblore level to determine the relative frequency of these orders.

![image](https://github.com/user-attachments/assets/49e47cfb-9f55-41b0-82d5-04c40f7bca39)

Log for this order:
```
2024-10-05 09:40:07 EDT [Client] INFO  c.C.varbits.CrowdsourcingVarbits - VarData(varType=0, varbitNumber=11315, oldValue=0, newValue=1, tick=46, isInInstance=false, location=WorldPoint(x=1395, y=9331, plane=0), metadata={Herblore=72, BHerblore=72})
2024-10-05 09:40:07 EDT [Client] INFO  c.C.varbits.CrowdsourcingVarbits - VarData(varType=0, varbitNumber=11317, oldValue=0, newValue=4, tick=46, isInInstance=false, location=WorldPoint(x=1395, y=9331, plane=0), metadata={Herblore=72, BHerblore=72})
2024-10-05 09:40:07 EDT [Client] INFO  c.C.varbits.CrowdsourcingVarbits - VarData(varType=0, varbitNumber=11319, oldValue=0, newValue=1, tick=46, isInInstance=false, location=WorldPoint(x=1395, y=9331, plane=0), metadata={Herblore=72, BHerblore=72})
```

This was motivated by this feedback: https://oldschool.runescape.wiki/w/Talk:Mastering_Mixology#Feedback_(Sat,_05_Oct_2024_02:50:00_GMT)