### PR TITLE
Replace usage of deprecated client.getCachedNpcs method

### DIFF
--- a/src/main/java/com/Crowdsourcing/monster_examine/MonsterExamine.java
+++ b/src/main/java/com/Crowdsourcing/monster_examine/MonsterExamine.java
@@ -46,7 +46,7 @@ public class MonsterExamine
         String target = event.getMenuTarget();
         if (target.startsWith("<col=00ff00>Monster Examine</col><col=ffffff> -> "))
         {
-            lastId = client.getCachedNPCs()[event.getId()].getComposition().getId();
+			lastId = client.getTopLevelWorldView().npcs().byIndex(event.getId()).getComposition().getId();
         }
     }
 


### PR DESCRIPTION
As mentioned by Adam in the RuneLite server yesterday [here](https://discord.com/channels/301497432909414422/419891709883973642/1335401709559877694), `client.getCachedNpcs()` will be removed later this month. 

This updates the plugin to instead use the worldview's `npcs().byIndex()` method.