### PR TITLE
Stuffed snake cooking

### DIFF
--- a/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
+++ b/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
@@ -147,6 +147,10 @@ public class CrowdsourcingMessages
 	private static final String CRATE_4714_CATLIKE_AGILITY_ATTEMPT = "You begin to lower yourself into the hole...";
 	private static final String CRATE_4714_CATLIKE_AGILITY_SUCCESS = "... and using your catlike agility land on all fours at the bottom of a large cavern!";
 
+	// Stuffed snake message box cooking messages
+	private static final String STUFFED_SNAKE_SUCCESS = "You cook the stuffed snake to perfection.";
+	private static final String STUFFED_SNAKE_FAILURE = "You burn the stuffed snake.";
+
   // Hallowed Sepulchre coffins
   private static final String SEPULCHRE_FAILURE = "You have been poisoned!";
   private static final String SEPULCHRE_FAILURE_ANTIPOISON = "You trigger a trap on the chest which poisons you!";
@@ -309,6 +313,12 @@ public class CrowdsourcingMessages
 			|| CRATE_4714_CATLIKE_AGILITY_SUCCESS.equals(message))
 		{
 			return createSkillMap(Skill.AGILITY);
+		}
+
+		if (STUFFED_SNAKE_SUCCESS.equals(message)
+			|| STUFFED_SNAKE_FAILURE.equals(message))
+		{
+			return createSkillMap(Skill.COOKING);
 		}
 
     if (SEPULCHRE_FAILURE.equals(message) || SEPULCHRE_SUCCESS.equals(message) || SEPULCHRE_FAILURE_ANTIPOISON.equals(message))


### PR DESCRIPTION
Stuffed snake cooking success and failure message box messages. Message box messages are also tracked by the chat message tracking.
<img width="675" height="129" alt="image" src="https://github.com/user-attachments/assets/983348a2-a47f-47d5-84ce-58ae356a9657" />
<img width="655" height="125" alt="image" src="https://github.com/user-attachments/assets/57d7cb0e-3fff-4205-b801-833e7119c8fd" />
