### PR TITLE
Crowdsource doom loot

### DIFF
--- a/src/main/java/com/Crowdsourcing/AdvancedCrowdsourcingPlugin.java
+++ b/src/main/java/com/Crowdsourcing/AdvancedCrowdsourcingPlugin.java
@@ -3,6 +3,7 @@ package com.Crowdsourcing;
 import com.Crowdsourcing.animation.CrowdsourcingAnimation;
 import com.Crowdsourcing.clues.CrowdsourcingClues;
 import com.Crowdsourcing.dialogue.CrowdsourcingDialogue;
+import com.Crowdsourcing.doom.CrowdsourcingDoom;
 import com.Crowdsourcing.experience.CrowdsourcingExperience;
 import com.Crowdsourcing.inventory.CrowdsourcingInventory;
 import com.Crowdsourcing.item_sighting.CrowdsourcingItemSighting;
@@ -118,6 +119,9 @@ public class AdvancedCrowdsourcingPlugin extends Plugin
 	@Inject
 	private CrowdsourcingStars stars;
 
+	@Inject
+	private CrowdsourcingDoom doom;
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -141,6 +145,7 @@ public class AdvancedCrowdsourcingPlugin extends Plugin
 		eventBus.register(toa);
 		eventBus.register(impling);
 		eventBus.register(stars);
+		eventBus.register(doom);
 
 		varbits.startUp();
 		experience.startUp();
@@ -171,6 +176,7 @@ public class AdvancedCrowdsourcingPlugin extends Plugin
 		eventBus.unregister(toa);
 		eventBus.unregister(impling);
 		eventBus.unregister(stars);
+		eventBus.unregister(doom);
 
 		varbits.shutDown();
 		stars.reset();

--- a/src/main/java/com/Crowdsourcing/doom/CrowdsourcingDoom.java
+++ b/src/main/java/com/Crowdsourcing/doom/CrowdsourcingDoom.java
@@ -1,0 +1,88 @@
+package com.Crowdsourcing.doom;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import com.Crowdsourcing.CrowdsourcingManager;
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.client.eventbus.Subscribe;
+
+
+public class CrowdsourcingDoom
+{
+    @Inject
+    public CrowdsourcingManager manager;
+
+    @Inject
+    public Client client;
+
+    private HashMap<Integer, Integer> prevDrops = new HashMap<>();
+    private int prevDelve = 0;
+
+    @Subscribe
+    public void onItemContainerChanged(ItemContainerChanged itemContainerChanged)
+    {
+        int id = itemContainerChanged.getContainerId();
+
+        if (id != InventoryID.DOM_LOOTPILE)
+        {
+            return;
+        }
+
+        String title = client.getWidget(InterfaceID.DomEndLevelUi.FRAME).getChild(1).getText(); // Level 2 Complete!
+        int currDelve = Integer.parseInt(title.split(" ")[1]);
+
+        if (currDelve != prevDelve + 1)
+        {
+            prevDrops = new HashMap<>();
+            prevDelve = 0;
+            return;
+        }
+
+        ItemContainer inv = itemContainerChanged.getItemContainer();
+
+        HashMap<Integer, Integer> currDrops = new HashMap<>();
+        for (Item item: inv.getItems())
+        {
+            currDrops.put(item.getId(), item.getQuantity());
+        }
+
+        ArrayList<DoomData> doomData = new ArrayList<>();
+        for (int itemId : currDrops.keySet())
+        {
+            int itemQty = currDrops.get(itemId);
+            if (!prevDrops.containsKey(itemId))
+            {
+                doomData.add(new DoomData(currDelve, itemId, itemQty));
+            }
+            else if (prevDrops.containsKey(itemId) && currDrops.get(itemId) > prevDrops.get(itemId))
+            {
+                int prevQty = prevDrops.get(itemId);
+                int newQty = itemQty - prevQty;
+                doomData.add(new DoomData(currDelve, itemId, newQty));
+            }
+        }
+
+        if (doomData.isEmpty() ||
+            (currDelve == 3 && doomData.size() > 2) ||
+            (currDelve != 3 && doomData.size() > 1))
+        {
+            prevDrops = new HashMap<>();
+            prevDelve = 0;
+            return;
+        }
+
+        for (DoomData data : doomData)
+        {
+            manager.storeEvent(data);
+        }
+
+        prevDrops = currDrops;
+        prevDelve = currDelve;
+    }
+}

--- a/src/main/java/com/Crowdsourcing/doom/DoomData.java
+++ b/src/main/java/com/Crowdsourcing/doom/DoomData.java
@@ -1,0 +1,12 @@
+package com.Crowdsourcing.doom;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DoomData {
+    private int delve;
+    private int dropId;
+    private int dropQty;
+}


### PR DESCRIPTION
My attempt at Doom crowdsourcing. No idea if this works, I won't be able to test it myself, but wanted to get this out there. The idea is to only get loot that changes between delves, not just the stack of all the items in the window. Note that there are guaranteed demon tears tertiary on every delve 3 and above, otherwise shouldn't be any tertiary items. In other words, people will always have 0 or 1 new distinct items each delve, except for delve 3 where they can have 0, 1, or 2 new distinct items.