### PR TITLE
Slug Menace blank rune shaping

### DIFF
--- a/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
+++ b/src/main/java/com/Crowdsourcing/messages/CrowdsourcingMessages.java
@@ -156,6 +156,10 @@ public class CrowdsourcingMessages
 	private static final String LEAVES_TRAP_SUCCESS = "You safely jump across.";
 	private static final String LEAVES_TRAP_FAILURE = "You try to jump across but you slip and fall.";
 
+	// Slug Menace air, earth, fire, mind and water blank rune
+	private static final String BLANK_RUNE_SUCCESS = "You manage to shape the rune essence into the desired shape.";
+	private static final String BLANK_RUNE_FAILURE = "You attempt to craft the stone but fail, destroying the essence.";
+
   // Hallowed Sepulchre coffins
   private static final String SEPULCHRE_FAILURE = "You have been poisoned!";
   private static final String SEPULCHRE_FAILURE_ANTIPOISON = "You trigger a trap on the chest which poisons you!";
@@ -330,6 +334,12 @@ public class CrowdsourcingMessages
 			|| LEAVES_TRAP_FAILURE.equals(message))
 		{
 			return createSkillMap(Skill.AGILITY);
+		}
+
+		if (BLANK_RUNE_SUCCESS.equals(message)
+			|| BLANK_RUNE_FAILURE.equals(message))
+		{
+			return createSkillMap(Skill.CRAFTING);
 		}
 
     if (SEPULCHRE_FAILURE.equals(message) || SEPULCHRE_SUCCESS.equals(message) || SEPULCHRE_FAILURE_ANTIPOISON.equals(message))


### PR DESCRIPTION
Shaping rune essence or pure essence with a chisel into a blank air rune, blank earth rune, blank fire rune, blank mind rune or blank water rune grants 2 crafting xp and is most likely only possible during the Slug Menace quest. The success message says rune essence even if you shape a pure essence. Runecrafting blank runes into slug menace runes has the same runecrafting success rate regardless of rune type<sup>[[1](https://web.archive.org/web/20220221180753/https://twitter.com/JagexAsh/status/1495821295715500032)]</sup>, so I think we can assume that the type of blank rune being made is irrelevant.
![image](https://github.com/user-attachments/assets/fe79d515-f327-4ebf-b033-ae46799def1b)
Chat message source: <https://youtu.be/DfaJPbEHGXw&t=680>
