### PR TITLE
Track metadata for loot tracker events

### DIFF
--- a/src/main/java/com/Crowdsourcing/AdvancedCrowdsourcingPlugin.java
+++ b/src/main/java/com/Crowdsourcing/AdvancedCrowdsourcingPlugin.java
@@ -7,6 +7,7 @@ import com.Crowdsourcing.doom_of_mokhaiotl.CrowdsourcingDoomOfMokhaiotl;
 import com.Crowdsourcing.experience.CrowdsourcingExperience;
 import com.Crowdsourcing.inventory.CrowdsourcingInventory;
 import com.Crowdsourcing.item_sighting.CrowdsourcingItemSighting;
+import com.Crowdsourcing.loot.CrowdsourcingLoot;
 import com.Crowdsourcing.messages.CrowdsourcingMessages;
 import com.Crowdsourcing.mlm.CrowdsourcingMLM;
 import com.Crowdsourcing.monster_examine.MonsterExamine;
@@ -122,6 +123,9 @@ public class AdvancedCrowdsourcingPlugin extends Plugin
 	@Inject
 	private CrowdsourcingDoomOfMokhaiotl doomOfMokhaiotl;
 
+	@Inject
+	private CrowdsourcingLoot loot;
+
 	@Override
 	protected void startUp() throws Exception
 	{
@@ -146,6 +150,7 @@ public class AdvancedCrowdsourcingPlugin extends Plugin
 		eventBus.register(impling);
 		eventBus.register(stars);
 		eventBus.register(doomOfMokhaiotl);
+		eventBus.register(loot);
 
 		varbits.startUp();
 		experience.startUp();
@@ -177,6 +182,7 @@ public class AdvancedCrowdsourcingPlugin extends Plugin
 		eventBus.unregister(impling);
 		eventBus.unregister(stars);
 		eventBus.unregister(doomOfMokhaiotl);
+		eventBus.unregister(loot);
 
 		varbits.shutDown();
 		stars.reset();

--- a/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
+++ b/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
@@ -1,0 +1,92 @@
+package com.Crowdsourcing.loot;
+
+import com.Crowdsourcing.CrowdsourcingManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.loottracker.LootReceived;
+
+@Slf4j
+public class CrowdsourcingLoot
+{
+	@Inject
+	Client client;
+
+	@Inject
+	ClientThread clientThread;
+
+	@Inject
+	CrowdsourcingManager manager;
+
+	// Clues
+	private static final Pattern CLUE_WARNING_MESSAGE = Pattern.compile("You have a sneaking suspicion.*");
+
+	// Rogue outfit
+	private static final String ROGUE_MESSAGE = "Your rogue clothing allows you to steal twice as much loot!";
+
+	// Fishing/mining standard messages
+	// "You catch a swordfish.", "You catch some shrimps.", "You catch a shark!", "You catch a scroll box!"
+	private static final Pattern FISHING_PATTERN = Pattern.compile("You catch .*");
+	private static final Pattern MINING_PATTERN = Pattern.compile("You manage to mine some .*");
+	private static final String MINING_CLUE_MESSAGE = "You find a scroll box!";
+
+	@Subscribe
+	public void onLootReceived(LootReceived event)
+	{
+		List<Map<String, Integer>> drops = new ArrayList<>();
+		event.getItems().forEach(item ->
+			drops.add(Map.of(
+				"id", item.getId(),
+				"qty", item.getQuantity()
+			))
+		);
+
+		clientThread.invokeLater(() ->
+			manager.storeEvent(new LootData(
+				event.getType(),
+				event.getName(),
+				drops,
+				event.getAmount(),
+				null,
+				(new LootMetadata(client)).toMap()
+			))
+		);
+	}
+
+	@Subscribe
+	public void onChatMessage(ChatMessage event)
+	{
+		ChatMessageType type = event.getType();
+		if (type != ChatMessageType.GAMEMESSAGE && type != ChatMessageType.SPAM)
+		{
+			return;
+		}
+
+		String message = event.getMessage();
+		if (CLUE_WARNING_MESSAGE.matcher(message).matches() ||
+			ROGUE_MESSAGE.equals(message) ||
+			FISHING_PATTERN.matcher(message).matches() ||
+			MINING_PATTERN.matcher(message).matches() ||
+			MINING_CLUE_MESSAGE.equals(message))
+		{
+			clientThread.invokeLater(() ->
+				manager.storeEvent(new LootData(
+					null,
+					"message",
+					null,
+					0,
+					message,
+					(new LootMetadata(client)).toMap()
+				))
+			);
+		}
+	}
+}

--- a/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
+++ b/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
@@ -56,7 +56,7 @@ public class CrowdsourcingLoot
 				drops,
 				event.getAmount(),
 				null,
-				(new LootMetadata(client)).toMap()
+				LootMetadata.getMap(client)
 			))
 		);
 	}
@@ -84,7 +84,7 @@ public class CrowdsourcingLoot
 					null,
 					0,
 					message,
-					(new LootMetadata(client)).toMap()
+					LootMetadata.getMap(client)
 				))
 			);
 		}

--- a/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
+++ b/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
@@ -2,6 +2,7 @@ package com.Crowdsourcing.loot;
 
 import com.Crowdsourcing.CrowdsourcingManager;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -13,6 +14,7 @@ import net.runelite.api.events.ChatMessage;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.loottracker.LootReceived;
+import net.runelite.http.api.loottracker.LootRecordType;
 
 @Slf4j
 public class CrowdsourcingLoot
@@ -55,7 +57,7 @@ public class CrowdsourcingLoot
 				event.getName(),
 				drops,
 				event.getAmount(),
-				null,
+				"",
 				LootMetadata.getMap(client)
 			))
 		);
@@ -79,10 +81,10 @@ public class CrowdsourcingLoot
 		{
 			clientThread.invokeLater(() ->
 				manager.storeEvent(new LootData(
-					null,
-					"message",
-					null,
-					0,
+					LootRecordType.UNKNOWN,
+					"MESSAGE",
+					Collections.emptyList(),
+					-1,
 					message,
 					LootMetadata.getMap(client)
 				))

--- a/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
+++ b/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
@@ -58,7 +58,7 @@ public class CrowdsourcingLoot
 				drops,
 				event.getAmount(),
 				"",
-				LootMetadata.getMap(client)
+				LootMetadata.getMap(client, event.getMetadata())
 			))
 		);
 	}
@@ -86,7 +86,7 @@ public class CrowdsourcingLoot
 					Collections.emptyList(),
 					-1,
 					message,
-					LootMetadata.getMap(client)
+					LootMetadata.getMap(client, -1)
 				))
 			);
 		}

--- a/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
+++ b/src/main/java/com/Crowdsourcing/loot/CrowdsourcingLoot.java
@@ -31,9 +31,6 @@ public class CrowdsourcingLoot
 	// Clues
 	private static final Pattern CLUE_WARNING_MESSAGE = Pattern.compile("You have a sneaking suspicion.*");
 
-	// Rogue outfit
-	private static final String ROGUE_MESSAGE = "Your rogue clothing allows you to steal twice as much loot!";
-
 	// Fishing/mining standard messages
 	// "You catch a swordfish.", "You catch some shrimps.", "You catch a shark!", "You catch a scroll box!"
 	private static final Pattern FISHING_PATTERN = Pattern.compile("You catch .*");
@@ -74,7 +71,6 @@ public class CrowdsourcingLoot
 
 		String message = event.getMessage();
 		if (CLUE_WARNING_MESSAGE.matcher(message).matches() ||
-			ROGUE_MESSAGE.equals(message) ||
 			FISHING_PATTERN.matcher(message).matches() ||
 			MINING_PATTERN.matcher(message).matches() ||
 			MINING_CLUE_MESSAGE.equals(message))

--- a/src/main/java/com/Crowdsourcing/loot/LootData.java
+++ b/src/main/java/com/Crowdsourcing/loot/LootData.java
@@ -1,0 +1,20 @@
+package com.Crowdsourcing.loot;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import net.runelite.http.api.loottracker.LootRecordType;
+
+@Data
+@AllArgsConstructor
+public class LootData
+{
+	private LootRecordType type;
+	private String eventId;
+	private List<Map<String, Integer>> drops;
+	private int amount;
+	private String message;
+	private HashMap<String, Object> metadata;
+}

--- a/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
+++ b/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
@@ -1,0 +1,168 @@
+package com.Crowdsourcing.loot;
+
+import com.Crowdsourcing.util.BoatLocation;
+import java.util.HashMap;
+import java.util.Map;
+import net.runelite.api.Client;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.DBTableID;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.gameval.VarbitID;
+
+public class LootMetadata
+{
+	private static final Map<Integer, String> VARBITS_CA = Map.of(
+		VarbitID.CA_TIER_STATUS_EASY, "easy",
+		VarbitID.CA_TIER_STATUS_MEDIUM, "medium",
+		VarbitID.CA_TIER_STATUS_HARD, "hard",
+		VarbitID.CA_TIER_STATUS_ELITE, "elite",
+		VarbitID.CA_TIER_STATUS_MASTER, "master",
+		VarbitID.CA_TIER_STATUS_GRANDMASTER, "grandmaster"
+	);
+	private static final int CA_CLAIMED = 2;
+
+	private static final Map<Integer, String> VARBITS_CLUE_WARNINGS = Map.of(
+		VarbitID.OPTION_TRAIL_REMINDER_BEGINNER, "beginner",
+		VarbitID.OPTION_TRAIL_REMINDER_EASY, "easy",
+		VarbitID.OPTION_TRAIL_REMINDER_MEDIUM, "medium",
+		VarbitID.OPTION_TRAIL_REMINDER_HARD, "hard",
+		VarbitID.OPTION_TRAIL_REMINDER_ELITE, "elite",
+		VarbitID.OPTION_TRAIL_REMINDER_MASTER, "master"
+	);
+	private static final int CLUE_WARNING_ENABLED = 0;
+
+	private static final Map<Integer, String> ROW_MAP = Map.ofEntries(
+		Map.entry(ItemID.RING_OF_WEALTH, "uncharged"),
+		Map.entry(ItemID.RING_OF_WEALTH_I, "uncharged (i)"),
+		Map.entry(ItemID.RING_OF_WEALTH_1, "charged"),
+		Map.entry(ItemID.RING_OF_WEALTH_2, "charged"),
+		Map.entry(ItemID.RING_OF_WEALTH_3, "charged"),
+		Map.entry(ItemID.RING_OF_WEALTH_4, "charged"),
+		Map.entry(ItemID.RING_OF_WEALTH_5, "charged"),
+		Map.entry(ItemID.RING_OF_WEALTH_I1, "charged (i)"),
+		Map.entry(ItemID.RING_OF_WEALTH_I2, "charged (i)"),
+		Map.entry(ItemID.RING_OF_WEALTH_I3, "charged (i)"),
+		Map.entry(ItemID.RING_OF_WEALTH_I4, "charged (i)"),
+		Map.entry(ItemID.RING_OF_WEALTH_I5, "charged (i)")
+	);
+
+	private static final int SLAYER_BOSS_TASK_ID = 98;
+
+	private final Client client;
+
+	private WorldPoint location;
+	private int tick;
+	private final Map<String, Boolean> combatAchievements = new HashMap<>();
+	private final Map<String, Boolean> clueWarnings = new HashMap<>();
+	private String ringOfWealth;
+	private String slayerTask;
+
+	public LootMetadata(Client client)
+	{
+		this.client = client;
+
+		setLocation();
+		setTick();
+		setCombatAchievements();
+		setClueWarnings();
+		setRingOfWealth();
+		setSlayerTask();
+	}
+
+	private void setLocation()
+	{
+		LocalPoint local = LocalPoint.fromWorld(client, client.getLocalPlayer().getWorldLocation());
+		if (local != null)
+		{
+			location = BoatLocation.fromLocal(client, local);
+		}
+	}
+
+	private void setTick()
+	{
+		tick = client.getTickCount();
+	}
+
+	private void setCombatAchievements()
+	{
+		VARBITS_CA.forEach((varbitId, caTier) ->
+			combatAchievements.put(caTier, client.getVarbitValue(varbitId) == CA_CLAIMED)
+		);
+	}
+
+	private void setClueWarnings()
+	{
+		VARBITS_CLUE_WARNINGS.forEach((varbitId, clueTier) ->
+			clueWarnings.put(clueTier, client.getVarbitValue(varbitId) == CLUE_WARNING_ENABLED)
+		);
+	}
+
+	private void setRingOfWealth()
+	{
+		ItemContainer equipmentContainer = client.getItemContainer(InventoryID.WORN);
+		if (equipmentContainer != null)
+		{
+			for (Map.Entry<Integer, String> entry : ROW_MAP.entrySet())
+			{
+				if (equipmentContainer.contains(entry.getKey()))
+				{
+					ringOfWealth = entry.getValue();
+					return;
+				}
+			}
+		}
+		ringOfWealth = "none";
+	}
+
+	private void setSlayerTask()
+	{
+		int slayerTaskQuantity = client.getVarpValue(VarPlayerID.SLAYER_COUNT);
+		if (slayerTaskQuantity > 0)
+		{
+			int taskId = client.getVarpValue(VarPlayerID.SLAYER_TARGET);
+
+			int taskDBRow;
+			if (taskId == SLAYER_BOSS_TASK_ID) /* from [proc,helper_slayer_current_assignment] */
+			{
+				var bossRows = client.getDBRowsByValue(
+					DBTableID.SlayerTaskSublist.ID,
+					DBTableID.SlayerTaskSublist.COL_TASK_SUBTABLE_ID,
+					0,
+					client.getVarbitValue(VarbitID.SLAYER_TARGET_BOSSID));
+
+				if (bossRows.isEmpty())
+				{
+					return;
+				}
+				taskDBRow = (Integer) client.getDBTableField(bossRows.get(0), DBTableID.SlayerTaskSublist.COL_TASK, 0)[0];
+			}
+			else
+			{
+				var taskRows = client.getDBRowsByValue(DBTableID.SlayerTask.ID, DBTableID.SlayerTask.COL_ID, 0, taskId);
+				if (taskRows.isEmpty())
+				{
+					return;
+				}
+				taskDBRow = taskRows.get(0);
+			}
+
+			slayerTask = (String) client.getDBTableField(taskDBRow, DBTableID.SlayerTask.COL_NAME_UPPERCASE, 0)[0];
+		}
+	}
+
+	public HashMap<String, Object> toMap()
+	{
+		return new HashMap<>() {{
+			put("location", location);
+			put("tick", tick);
+			put("combatAchievements", combatAchievements);
+			put("clueWarnings", clueWarnings);
+			put("ringOfWealth", ringOfWealth);
+			put("slayerTask", slayerTask);
+		}};
+	}
+}

--- a/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
+++ b/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
@@ -50,6 +50,18 @@ public class LootMetadata
 		Map.entry(ItemID.RING_OF_WEALTH_I5, "charged (i)")
 	);
 
+	// https://oldschool.runescape.wiki/w/RuneScape:Varbit/4067
+	private static final Map<Integer, String> SLAYER_MASTERS = Map.of(
+		1, "Turael/Aya",
+		2, "Mazchna/Achtryn",
+		3, "Vannaka",
+		4, "Chaeldar",
+		5, "Duradel/Kuradal",
+		6, "Nieve/Steve",
+		7, "Krystilia",
+		8, "Konar quo Maten",
+		9, "Spria"
+	);
 	private static final int SLAYER_BOSS_TASK_ID = 98;
 
 	private final Client client;
@@ -60,6 +72,7 @@ public class LootMetadata
 	private final Map<String, Boolean> clueWarnings = new HashMap<>();
 	private String ringOfWealth;
 	private String slayerTask;
+	private String slayerMaster;
 
 	public LootMetadata(Client client)
 	{
@@ -115,7 +128,6 @@ public class LootMetadata
 				}
 			}
 		}
-		ringOfWealth = "none";
 	}
 
 	private void setSlayerTask()
@@ -151,6 +163,7 @@ public class LootMetadata
 			}
 
 			slayerTask = (String) client.getDBTableField(taskDBRow, DBTableID.SlayerTask.COL_NAME_UPPERCASE, 0)[0];
+			slayerMaster = SLAYER_MASTERS.get(client.getVarbitValue(VarbitID.SLAYER_MASTER));
 		}
 	}
 
@@ -163,6 +176,7 @@ public class LootMetadata
 			put("clueWarnings", clueWarnings);
 			put("ringOfWealth", ringOfWealth);
 			put("slayerTask", slayerTask);
+			put("slayerMaster", slayerMaster);
 		}};
 	}
 }

--- a/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
+++ b/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
@@ -1,10 +1,13 @@
 package com.Crowdsourcing.loot;
 
 import com.Crowdsourcing.util.BoatLocation;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import net.runelite.api.Client;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.WorldType;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.gameval.DBTableID;
@@ -73,6 +76,8 @@ public class LootMetadata
 	private String ringOfWealth;
 	private String slayerTask;
 	private String slayerMaster;
+	private final List<String> worldTypes = new ArrayList<>();
+	private int worldNumber;
 
 	public LootMetadata(Client client)
 	{
@@ -83,7 +88,8 @@ public class LootMetadata
 		setCombatAchievements();
 		setClueWarnings();
 		setRingOfWealth();
-		setSlayerTask();
+		setSlayerInfo();
+		setWorldInfo();
 	}
 
 	private void setLocation()
@@ -130,7 +136,7 @@ public class LootMetadata
 		}
 	}
 
-	private void setSlayerTask()
+	private void setSlayerInfo()
 	{
 		int slayerTaskQuantity = client.getVarpValue(VarPlayerID.SLAYER_COUNT);
 		if (slayerTaskQuantity > 0)
@@ -167,6 +173,20 @@ public class LootMetadata
 		}
 	}
 
+	private void setWorldInfo()
+	{
+		worldNumber = client.getWorld();
+
+		for (WorldType wt : client.getWorldType())
+		{
+			worldTypes.add(wt.toString());
+		}
+		if (!worldTypes.contains("MEMBERS"))
+		{
+			worldTypes.add("FREE");
+		}
+	}
+
 	public HashMap<String, Object> toMap()
 	{
 		return new HashMap<>() {{
@@ -177,6 +197,8 @@ public class LootMetadata
 			put("ringOfWealth", ringOfWealth);
 			put("slayerTask", slayerTask);
 			put("slayerMaster", slayerMaster);
+			put("worldTypes", worldTypes);
+			put("worldNumber", worldNumber);
 		}};
 	}
 }

--- a/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
+++ b/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
@@ -154,7 +154,7 @@ public class LootMetadata
 		return client.getWorld();
 	}
 
-	public static HashMap<String, Object> getMap(Client client)
+	public static HashMap<String, Object> getMap(Client client, Object lootTrackerMetadata)
 	{
 		return new HashMap<>() {{
 			put("location", getLocation(client));
@@ -168,6 +168,7 @@ public class LootMetadata
 			put("slayerMasterID", getSlayerMasterID(client));
 			put("worldTypes", getWorldTypes(client));
 			put("worldNumber", getWorldNumber(client));
+			put("lootTrackerMetadata", lootTrackerMetadata != null ? lootTrackerMetadata : -1);
 		}};
 	}
 }


### PR DESCRIPTION
Essentially this is the same as #55 but there were a decent amount of changes necessary so I thought I'd just try to organize it a bit better and have us take a fresh look at it.

This subscribes to [LootReceived](https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootReceived.java) events and attaches a bunch of metadata to those:
- player location
- game tick
- combat achievements claimed
- clue warning settings ("You have a sneaking suspicion...")
- which type of ring of wealth is worn
- slayer task
- slayer master
- world number
- world type

Conspicuously missing is the NPC ID (if applicable) which is not available to us without re-implementing loot tracker, but I've opened https://github.com/runelite/runelite/pull/19668 for that as well.

Example output:
```json
{
    "type": "PICKPOCKET",
    "eventId": "Man",
    "drops": [
        {
            "id": 22521,
            "qty": 1
        }
    ],
    "amount": 1,
    "metadata": {
        "clueWarnings": {
            "elite": true,
            "beginner": true,
            "hard": true,
            "medium": true,
            "easy": true,
            "master": true
        },
        "location": {
            "x": 3102,
            "y": 3510,
            "plane": 0
        },
        "tick": 10,
        "slayerTask": "Rogues",
        "slayerMaster":"Krystilia",
        "worldTypes":["MEMBERS","SKILL_TOTAL"],
        "worldNumber":449,
        "combatAchievements": {
            "elite": false,
            "hard": false,
            "medium": true,
            "grandmaster": false,
            "easy": true,
            "master": false
        },
        "ringOfWealth": "charged (i)"
    }
}
```