### PR TITLE
Track boat location for scenery + NPCs

### DIFF
--- a/src/main/java/com/Crowdsourcing/animation/CrowdsourcingAnimation.java
+++ b/src/main/java/com/Crowdsourcing/animation/CrowdsourcingAnimation.java
@@ -1,6 +1,7 @@
 package com.Crowdsourcing.animation;
 
 import com.Crowdsourcing.CrowdsourcingManager;
+import com.Crowdsourcing.util.BoatLocation;
 import java.util.HashSet;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +51,7 @@ public class CrowdsourcingAnimation
 				{
 					return;
 				}
-				WorldPoint location = WorldPoint.fromLocalInstance(client, local);
+				WorldPoint location = BoatLocation.fromLocal(client, local);
 				boolean isInInstance = client.isInInstancedRegion();
 
 				// Create and send the animation data
@@ -83,7 +84,7 @@ public class CrowdsourcingAnimation
 				{
 					return;
 				}
-				WorldPoint location = WorldPoint.fromLocalInstance(client, local);
+				WorldPoint location = BoatLocation.fromLocal(client, local);
 				boolean isInInstance = client.isInInstancedRegion();
 
 				// Create and send the animation data

--- a/src/main/java/com/Crowdsourcing/npc_respawn/CrowdsourcingNpcRespawn.java
+++ b/src/main/java/com/Crowdsourcing/npc_respawn/CrowdsourcingNpcRespawn.java
@@ -1,6 +1,7 @@
 package com.Crowdsourcing.npc_respawn;
 
 import com.Crowdsourcing.CrowdsourcingManager;
+import com.Crowdsourcing.util.BoatLocation;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
@@ -63,7 +64,7 @@ public class CrowdsourcingNpcRespawn {
             boolean isInInstance = false;
             if (local != null)
             {
-                location = WorldPoint.fromLocalInstance(client, local);
+                location = BoatLocation.fromLocal(client, local);
                 isInInstance = client.isInInstancedRegion();
             }
             manager.storeEvent(new NpcRespawnData(index, npc.getId(), respawnTime, location, isInInstance));

--- a/src/main/java/com/Crowdsourcing/npc_sighting/CrowdsourcingNpcSighting.java
+++ b/src/main/java/com/Crowdsourcing/npc_sighting/CrowdsourcingNpcSighting.java
@@ -1,5 +1,6 @@
 package com.Crowdsourcing.npc_sighting;
 
+import com.Crowdsourcing.util.BoatLocation;
 import com.google.common.collect.ImmutableSet;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -71,7 +72,7 @@ public class CrowdsourcingNpcSighting
 		{
 			return;
 		}
-		WorldPoint location = WorldPoint.fromLocalInstance(client, local);
+		WorldPoint location = BoatLocation.fromLocal(client, local);
 		boolean isInInstance = client.isInInstancedRegion();
 		NpcSightingData data = new NpcSightingData(id, index, rate, isSpawn, world, isInInstance, location);
 		manager.storeEvent(data);

--- a/src/main/java/com/Crowdsourcing/scenery/CrowdsourcingScenery.java
+++ b/src/main/java/com/Crowdsourcing/scenery/CrowdsourcingScenery.java
@@ -79,10 +79,6 @@ public class CrowdsourcingScenery
 			}
 		}
 		LocalPoint local = LocalPoint.fromWorld(client, baseLocation);
-		if (local == null)
-		{
-			return;
-		}
 		WorldPoint location = BoatLocation.fromLocal(client, local);
 		manager.storeEvent(new SceneryEvent(type, location, id, rate));
 	}

--- a/src/main/java/com/Crowdsourcing/scenery/CrowdsourcingScenery.java
+++ b/src/main/java/com/Crowdsourcing/scenery/CrowdsourcingScenery.java
@@ -1,5 +1,6 @@
 package com.Crowdsourcing.scenery;
 
+import com.Crowdsourcing.util.BoatLocation;
 import com.google.common.collect.ImmutableSet;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -78,7 +79,11 @@ public class CrowdsourcingScenery
 			}
 		}
 		LocalPoint local = LocalPoint.fromWorld(client, baseLocation);
-		WorldPoint location = WorldPoint.fromLocalInstance(client, local);
+		if (local == null)
+		{
+			return;
+		}
+		WorldPoint location = BoatLocation.fromLocal(client, local);
 		manager.storeEvent(new SceneryEvent(type, location, id, rate));
 	}
 

--- a/src/main/java/com/Crowdsourcing/util/BoatLocation.java
+++ b/src/main/java/com/Crowdsourcing/util/BoatLocation.java
@@ -15,8 +15,7 @@ public class BoatLocation
 			return null;
 		}
 
-		WorldView wv = client.getLocalPlayer().getWorldView();
-		int wvid = wv.getId();
+		int wvid = local.getWorldView();
 		boolean isOnBoat = wvid != -1;
 		if (isOnBoat)
 		{


### PR DESCRIPTION
NPCs and scenery can spawn on boats too, get proper location for them. I believe the point this returns is the tile that the boat's center of rotation intersects? Something like that. Which means we don't actually know the *exact* tile of a boat NPC/scenery, just roughly where the boat is when some event happens involving the entity on the boat.

I don't think we generally care for more detail than that, really. If we really want to know where something like a cargo hold spawns in the boat's coordinate system, that's something we could do, but we'd do it separately.

Accounting for scenery on boats fixes #71 