### PR TITLE
track port task ids

### DIFF
--- a/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
+++ b/src/main/java/com/Crowdsourcing/loot/LootMetadata.java
@@ -41,6 +41,12 @@ public class LootMetadata
 
 	private static final String LEAGUES_WORLD_TYPE = WorldType.SEASONAL.toString();
 
+	private static final int BOUNTY_TASK_ITEM_COUNTER_1 = 14662;
+	private static final int BOUNTY_TASK_ITEM_COUNTER_2 = 14663;
+	private static final int BOUNTY_TASK_ITEM_COUNTER_3 = 14819;
+	private static final int BOUNTY_TASK_ITEM_COUNTER_4 = 15370;
+	private static final int BOUNTY_TASK_ITEM_COUNTER_5 = 15397;
+
 	private static Map<String, Integer> getLocation(Client client)
 	{
 		Map<String, Integer> location = new HashMap<>();
@@ -67,10 +73,10 @@ public class LootMetadata
 		return Map.of(
 			"easy", isClaimed.apply(VarbitID.CA_TIER_STATUS_EASY),
 			"medium", isClaimed.apply(VarbitID.CA_TIER_STATUS_MEDIUM),
-			"hard",isClaimed.apply(VarbitID.CA_TIER_STATUS_HARD),
-			"elite",isClaimed.apply(VarbitID.CA_TIER_STATUS_ELITE),
-			"master",isClaimed.apply(VarbitID.CA_TIER_STATUS_MASTER),
-			"grandmaster",isClaimed.apply(VarbitID.CA_TIER_STATUS_GRANDMASTER)
+			"hard", isClaimed.apply(VarbitID.CA_TIER_STATUS_HARD),
+			"elite", isClaimed.apply(VarbitID.CA_TIER_STATUS_ELITE),
+			"master", isClaimed.apply(VarbitID.CA_TIER_STATUS_MASTER),
+			"grandmaster", isClaimed.apply(VarbitID.CA_TIER_STATUS_GRANDMASTER)
 		);
 	}
 
@@ -183,9 +189,32 @@ public class LootMetadata
 		);
 	}
 
+	private static List<Integer> getPortTaskIDs(Client client)
+	{
+		return List.of(
+			client.getVarbitValue(VarbitID.PORT_TASK_SLOT_0_ID),
+			client.getVarbitValue(VarbitID.PORT_TASK_SLOT_1_ID),
+			client.getVarbitValue(VarbitID.PORT_TASK_SLOT_2_ID),
+			client.getVarbitValue(VarbitID.PORT_TASK_SLOT_3_ID),
+			client.getVarbitValue(VarbitID.PORT_TASK_SLOT_4_ID)
+		);
+	}
+
+	private static List<Integer> getPortTaskCounts(Client client)
+	{
+		return List.of(
+			client.getVarbitValue(BOUNTY_TASK_ITEM_COUNTER_1),
+			client.getVarbitValue(BOUNTY_TASK_ITEM_COUNTER_2),
+			client.getVarbitValue(BOUNTY_TASK_ITEM_COUNTER_3),
+			client.getVarbitValue(BOUNTY_TASK_ITEM_COUNTER_4),
+			client.getVarbitValue(BOUNTY_TASK_ITEM_COUNTER_5)
+		);
+	}
+
 	public static HashMap<String, Object> getMap(Client client, Object lootTrackerMetadata)
 	{
-		HashMap<String, Object> metadata = new HashMap<>() {{
+		HashMap<String, Object> metadata = new HashMap<>()
+		{{
 			put("location", getLocation(client));
 			put("tick", getTick(client));
 			put("combatAchievements", getCombatAchievements(client));
@@ -197,6 +226,8 @@ public class LootMetadata
 			put("slayerMasterID", getSlayerMasterID(client));
 			put("worldNumber", getWorldNumber(client));
 			put("lootTrackerMetadata", lootTrackerMetadata != null ? lootTrackerMetadata : -1);
+			put("portTaskIDs", getPortTaskIDs(client));
+			put("portTaskCounts", getPortTaskCounts(client));
 		}};
 
 		List<String> worldTypes = getWorldTypes(client);


### PR DESCRIPTION
Drop rates for monster parts can now vary if you have a certain bounty task. This adds an array of task IDs which are stored in column 0 of https://abextm.github.io/cache2/#/viewer/dbtable/197

```json
{"portTaskIDs":[561,0,0,0,0],"portTaskCounts":[5,0,0,0,0],...}
```